### PR TITLE
Added variables for library and binary installation directory

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -141,11 +141,19 @@ target_link_libraries(emf2svg-conv
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -Wall")
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -std=c11 -Wall")
 
+if (NOT LIB_INSTALL_DIR)
+    set(LIB_INSTALL_DIR lib)
+endif ()
+
+if (NOT BIN_INSTALL_DIR)
+    set(BIN_INSTALL_DIR bin)
+endif ()
+
 # install binaries and library
 INSTALL(TARGETS emf2svg emf2svg-conv
-  RUNTIME DESTINATION bin
-  LIBRARY DESTINATION lib
-  ARCHIVE DESTINATION lib
+  RUNTIME DESTINATION ${BIN_INSTALL_DIR}
+  LIBRARY DESTINATION ${LIB_INSTALL_DIR}
+  ARCHIVE DESTINATION ${LIB_INSTALL_DIR}
 )
 
 # install header file


### PR DESCRIPTION
This adds a variable to the library and binary installation directory so they can be easily overridden on command line invocation of cmake.
I'm not sure about other distribution ecosystems, but in Fedora/RHEL/CentOS the cmake rpm macros set LIB_INSTALL_DIR depending on target architecture, so this would place the shared object(s) in the correct directories (currently they are placed in ${prefix}/lib which might be wrong in most cases, since nowadays it's most likely ${prefix}/lib64).
Note that this leaves the default values untouched just as they were before (both default to 'lib') if the variables are not set.